### PR TITLE
Update version to 0.12.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "phik" %}
-{% set version = "0.12.4" %}
+{% set version = "0.12.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,15 +7,16 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d4d53274685e56fb08088505b4eec70be07f2f8044e7961ca02b399e42c37025
+  sha256: dfc15a9166ab0dcfe3f5f60de606fe9ce064a09af2dd212e726ed3625b795332
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<38]
+  skip: True  # [py<39]
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - make  # [linux]
     - cmake >=3.17
@@ -26,7 +27,6 @@ requirements:
     - wheel
     - scikit-build-core >=0.3.3
     - pybind11
-    - pip
   run:
     - python
     - numpy >=1.18.0


### PR DESCRIPTION
phik 0.12.5

**Destination channel:** defaults

### Links

- [PKG-11529](https://anaconda.atlassian.net/browse/PKG-11529) 
- [Upstream repository](https://github.com/KaveIO/PhiK/tree/v0.12.5)
### Explanation of changes:

- New version number
- update dependency


[PKG-11529]: https://anaconda.atlassian.net/browse/PKG-11529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ